### PR TITLE
feat: Enable Dolby audio codecs

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -26,6 +26,8 @@ resolutions:
 audio_codecs:
   - aac
   - opus
+  - ac3
+  - eac3
 video_codecs:
   - h264
   - hw:vp9


### PR DESCRIPTION
Audio conversion is not a heavy task and allows us to easily test it in Shaka Player.

Note: AC-3 and EC-3 is supported in Safari, Edge-Windows, Opera-Windows, Opera-macOS and in many SmartTVs