### PR TITLE
feat: Enable FLAC audio codec

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -28,6 +28,7 @@ audio_codecs:
   - opus
   - ac3
   - eac3
+  - flac
 video_codecs:
   - h264
   - hw:vp9


### PR DESCRIPTION
Audio conversion is not a heavy task and allows us to easily test it in Shaka Player.