### PR TITLE
fix: Fix service shutdown

### DIFF
--- a/shaka-player-history.service
+++ b/shaka-player-history.service
@@ -26,6 +26,9 @@ Type=simple
 User=shaka-player-history
 ExecStart=/usr/bin/xvfb-run -a /opt/shaka-player-history/launch-streamer.sh
 Restart=always
+# Mixed kill mode helps kill off a misbehaving Gource instance after everything
+# else has been shut down.
+KillMode=mixed
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Sometimes, Gource does not get killed, causing the service shutdown to hang for a few minutes.  Setting KillMode=mixed in the service definition tells systemd to send SIGTERM to the main process, then SIGKILL (which cannot be ignored) to all other processes in the group.  This cleans up Gource right away.