### PR TITLE
perf: Drop EAC3 & FLAC

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -27,7 +27,6 @@ audio_codecs:
   - aac
   - opus
   - ac3
-  - eac3
   - flac
 video_codecs:
   - hw:h264


### PR DESCRIPTION
No point to EAC3 for stereo audio.  Its main advantage over AC3 is support for more channels.  So don't waste CPU cycles on it.

I am only dropping FLAC because even with EAC3 gone, our encoder device was still falling behind.  With both of those gone, it is keeping up again.