### PR TITLE
feat: Add tools, including speed monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ to visualize another repository:
  - `scripts/update-git.sh` and `sources/pre-release.log` hard-code the repo URL https://github.com/shaka-project/shaka-player and certain pre-historical details about Shaka Player
  - `scripts/rename-aliases.sh` and `sources/user-images` are specific to Shaka Player committers
  - `sources/title.txt` mentions Shaka Player
- - `launch-streamer.sh` hard-codes the output bucket gs://shaka-live-assets/
+ - `launch-streamer.sh` and `tools/clear-bucket.sh` hard-code the output bucket gs://shaka-live-assets/
 
 
 ## Service Installation
@@ -90,14 +90,21 @@ sudo systemctl start shaka-player-history
 
 ## Checking Service Logs
 
+To simply check the raw service logs, use this script:
+
 ```sh
-journalctl -axefu shaka-player-history.service
+./tools/watch-logs.sh
 ```
 
-You can see the uptime of the stream after "time=", and if everything is
-healthy and keeping up with real time, you should see status ending with "1x".
-Ex:
+To get an interpreted view of those logs, use this script:
 
+```sh
+./tools/monitor-encoder-speed.py
 ```
-frame=112832 fps= 25 q=19.0 q=21.0 q=-0.0 q=-0.0 q=35.0 q=31.0 size= 1092696KiB time=01:15:11.12 bitrate=1984.3kbits/s speed=   1x
+
+If everything is healthy and keeping up with real time, the service should
+eventually reach a speed of 1.0x.  Ex:
+
+```json
+{'TS': '2025-01-15T17:52:31.344017', 'SPEED': 1.0}
 ```

--- a/tools/become-service-account.sh
+++ b/tools/become-service-account.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Shaka Player History Live Stream
+#
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -x
+
+# Become the service account, for maintenance or experimentation.
+exec sudo su shaka-player-history -s /bin/bash

--- a/tools/clear-bucket.sh
+++ b/tools/clear-bucket.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Shaka Player History Live Stream
+#
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -x
+
+# Clear the bucket.  Use between stopping and starting the service if you want
+# to wipe out the old content.
+gsutil -m rm -r gs://shaka-live-assets/player-source/
+gsutil -m rm -r gs://shaka-live-assets/player-source.*

--- a/tools/monitor-encoder-speed.py
+++ b/tools/monitor-encoder-speed.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+
+# Shaka Player History Live Stream
+#
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Monitor shaka-player-history encoder speed and other events."""
+
+import argparse
+import json
+import re
+import select
+import systemd.journal
+
+
+UNIT_NAME = 'shaka-player-history.service'
+
+
+def main():
+  parser = argparse.ArgumentParser(
+      description=__doc__,
+      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+  parser.add_argument('-n', '--number', type=int,
+          default=100,
+          help='How many recent logs to show (0 == all)')
+  parser.add_argument('--follow', '-f', action='store_true', default=False,
+          help='Show the most recent logs, then wait for new logs.')
+  args = parser.parse_args()
+
+  j = systemd.journal.Reader()
+  j.add_match(_SYSTEMD_UNIT=UNIT_NAME)
+  j.add_disjunction()
+  j.add_match(UNIT=UNIT_NAME)
+
+  # Seek to |number| before the end, with respect to our filters.  This happens
+  # iteratively so we can run our filters on each entry.
+  j.seek_tail()
+  seeked = 0
+  while seeked <= args.number:
+    raw_log = j.get_previous()
+    if parse_log(raw_log) is not None:
+      seeked += 1
+
+  flush_logs(j)
+
+  # If we're following, we use select.poll to wait for new events.
+  if args.follow:
+    p = select.poll()
+    p.register(j, j.get_events())
+
+    try:
+      while True:
+        p.poll()
+        flush_logs(j)
+    except KeyboardInterrupt:
+      pass
+
+
+def flush_logs(j):
+  for raw_log in j:
+    log = parse_log(raw_log)
+    if log:
+      log['TS'] = format_timestamp(log['TS'])
+      print(log)
+
+
+def format_timestamp(ts):
+  return ts.isoformat()
+
+
+def parse_log(log):
+  if log.get('UNIT') == UNIT_NAME:
+    # This is init logging about our service.
+    parsed = parse_init_log(log)
+  else:
+    # This is a log from our service itself.
+    parsed = parse_unit_log(log)
+
+  # Could be None to indicate a log we're skipping.
+  if parsed:
+    return parsed
+
+
+def parse_init_log(log):
+  if 'JOB_TYPE' in log:
+    return {
+      'TS': log['__REALTIME_TIMESTAMP'],
+      'JOB_TYPE': log['JOB_TYPE'],
+      'MESSAGE': log['MESSAGE'],
+    }
+  return None
+
+
+def parse_unit_log(log):
+  parsed = {
+    'TS': log['__REALTIME_TIMESTAMP'],
+  }
+
+  message = log['MESSAGE']
+  # Using .* to match the last possible instance in the line
+  match_speed = re.search(r'.*speed=\s*([0-9.]+)x', message)
+  match_configs = re.search(r'Configs: (.*)', message)
+
+  if match_speed:
+    speed = float(match_speed.group(1))
+    parsed['SPEED'] = speed
+  elif match_configs:
+    parsed['CONFIGS'] = json.loads(match_configs.group(1))
+  elif 'Fast-forward' in message:
+    parsed['LOOP'] = True
+    parsed['NEW_COMMITS'] = True
+  elif 'Already up to date' in message:
+    parsed['LOOP'] = True
+    parsed['NEW_COMMITS'] = False
+  else:
+    return None
+
+  return parsed
+
+
+if __name__ == '__main__':
+  main()

--- a/tools/watch-logs.sh
+++ b/tools/watch-logs.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Shaka Player History Live Stream
+#
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -x
+
+# Watch the full logs from the service, live.
+journalctl -axefu shaka-player-history.service


### PR DESCRIPTION
Add several tools, most of which are very simple shell scripts:
 - tools/become-service-account.sh: Impersonate the service account with sudo & su
 - tools/clear-bucket.sh: Clear the storage bucket with gsutil
 - tools/watch-logs.sh: Watch service logs with journalctl
 - tools/monitor-encoder-speed.py: Fetch systemd service logs and interpret them to give a history of encoder speed, configs, and various important lifecycle events

The usefulness of the monitor tool is best illustrated by an example of the output:

```json
{'TS': '2025-01-15T16:35:46.979804', 'JOB_TYPE': 'stop', 'MESSAGE': 'Stopping Shaka Player History...'}
{'TS': '2025-01-15T16:35:47.070045', 'JOB_TYPE': 'restart', 'MESSAGE': 'Stopped Shaka Player History.'}
{'TS': '2025-01-15T16:35:47.081954', 'JOB_TYPE': 'start', 'MESSAGE': 'Started Shaka Player History.'}
{'TS': '2025-01-15T16:35:47.237337', 'CONFIGS': {'input': {'inputs': [{'input_type': 'external_command', 'media_type': 'video', 'frame_rate': 25, 'resolution': '720p', 'name': 'bash scripts/gource.sh $SHAKA_STREAMER_EXTERNAL_COMMAND_OUTPUT', 'extra_input_args': '-f image2pipe -framerate 25 -re', 'filters': ['pad=1280:720:20:20']}, {'input_type': 'looped_file', 'name': 'intermediate/audio_loop.mp4', 'media_type': 'audio'}]}, 'pipeline': {'streaming_mode': 'live', 'resolutions': ['720p', '480p'], 'audio_codecs': ['aac', 'opus', 'ac3', 'flac'], 'video_codecs': ['h264', 'hw:vp9', 'av1'], 'channel_layouts': ['stereo'], 'manifest_format': ['dash', 'hls'], 'dash_output': 'player-source.mpd', 'hls_output': 'player-source.m3u8', 'segment_folder': 'player-source', 'segment_size': 4, 'availability_window': 3600, 'presentation_delay': 60, 'update_period': 8}, 'bitrate': {}}}
{'TS': '2025-01-15T16:35:47.621152', 'LOOP': True, 'NEW_COMMITS': False}
{'TS': '2025-01-15T16:38:51.857862', 'SPEED': 0.989}
{'TS': '2025-01-15T16:47:59.540725', 'SPEED': 0.997}
{'TS': '2025-01-15T16:51:01.590094', 'SPEED': 0.998}
{'TS': '2025-01-15T16:54:04.153924', 'SPEED': 0.998}
{'TS': '2025-01-15T17:43:24.690464', 'SPEED': 0.999}
{'TS': '2025-01-15T17:43:24.696925', 'LOOP': True, 'NEW_COMMITS': True}
{'TS': '2025-01-15T17:46:26.720181', 'SPEED': 1.0}
{'TS': '2025-01-15T17:49:29.282240', 'SPEED': 1.0}
```

You can see when the service starts and stops, what the configs are for any given run, when the stream loops, whether there are new commits at loop time, and the average throughput of the service.  If the speed dips, we can look to see what events happened around that time.  If the speed can't reach or sustain 1x, we can look at the configs to see if a codec change might explain the low throughput.

The output is lines of JSON, which could potentially be ingested by another tool to create a dashboard.