### PR TITLE
feat: Add HEVC

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -29,8 +29,9 @@ audio_codecs:
   - ac3
   - flac
 video_codecs:
-  - hw:h264
+  - h264
   - hw:vp9
+  - hw:hevc
   - av1
 channel_layouts:
   - stereo


### PR DESCRIPTION
With new improvements to shaka-streamer's upload speed, we can now stream H264, VP9, HEVC, and AV1 with AAC, Opus, AC3, and FLAC.

Our encoding device's average throughput reaches 1x after 70 minutes of streaming.