### PR TITLE
chore: Update shaka-streamer syntax

### DIFF
--- a/launch-streamer.sh
+++ b/launch-streamer.sh
@@ -53,5 +53,5 @@ fi
 $streamer_binary \
   -i config/input.yaml \
   -p config/pipeline.yaml \
-  -c gs://shaka-live-assets/ \
+  -o gs://shaka-live-assets/ \
   --log-configs


### PR DESCRIPTION
-c for cloud upload is deprecated.  Now we just use -o (output), whether the output is cloud or local.